### PR TITLE
promtail-6-1:  Golang 1.24 and loki v3.5.3 changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "loki"]
 	path = loki
 	url = https://github.com/ibmstorage/loki.git
-	branch = release-8.1
+	branch = release-6.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG REMOTE_SOURCE_DIR
 
 LABEL com.redhat.component="promtail-container"
 LABEL name="promtail"
-LABEL version="v2.4.0"
+LABEL version="v3.5.3"
 LABEL summary="Provides promtail container"
 LABEL io.k8s.display-name="Promtail container"
 LABEL maintainer="Guillaume Abrioux <gabrioux@redhat.com>"


### PR DESCRIPTION
This PR contains the following changes,

[1] Golang updated to 1.24
[2] Loki updated to tag-v3.5.3